### PR TITLE
feat(tweet-getter): prevent requests when tweet is already synced

### DIFF
--- a/src/helpers/tweet/get-eligible-tweet.ts
+++ b/src/helpers/tweet/get-eligible-tweet.ts
@@ -1,12 +1,10 @@
 import { Tweet } from '@the-convocation/twitter-scraper';
 
 import { DEBUG } from '../../constants.js';
-import { Cache } from '../../types/index.js';
 import { getPostExcerpt } from '../post/get-post-excerpt.js';
-import { isTweetCached, keepRecentTweets, keepSelfQuotes, keepSelfReplies } from './index.js';
+import { keepRecentTweets, keepSelfQuotes, keepSelfReplies } from './index.js';
 
-export const getEligibleTweet = async (tweet: Tweet, cache: Cache): Promise<Tweet | undefined> => {
-    const notCached = !isTweetCached(tweet, cache);
+export const getEligibleTweet = async (tweet: Tweet): Promise<Tweet | undefined> => {
     const notRetweet = !tweet.isRetweet;
 
     const isSelfReply = await keepSelfReplies(tweet);
@@ -14,7 +12,7 @@ export const getEligibleTweet = async (tweet: Tweet, cache: Cache): Promise<Twee
 
     const isRecentTweet = keepRecentTweets(tweet);
 
-    const keep = notCached && notRetweet && isSelfReply && isSelfQuote && isRecentTweet;
+    const keep = notRetweet && isSelfReply && isSelfQuote && isRecentTweet;
 
     // Remove quote & reply tweets data if not self-made
     const eligibleTweet = {

--- a/src/services/tweets-getter.service.ts
+++ b/src/services/tweets-getter.service.ts
@@ -5,7 +5,7 @@ import { TWITTER_HANDLE } from '../constants.js';
 import { getCache } from '../helpers/cache/index.js';
 import { oraPrefixer } from '../helpers/logs/ora-prefixer.js';
 import { getEligibleTweet } from '../helpers/tweet/get-eligible-tweet.js';
-import { formatTweetText,getTweetIdFromPermalink } from '../helpers/tweet/index.js';
+import { formatTweetText, getTweetIdFromPermalink, isTweetCached } from '../helpers/tweet/index.js';
 
 const pullContentStats = (tweets: Tweet[], title: string) => {
     const stats = {
@@ -28,7 +28,7 @@ export const tweetsGetterService = async (twitterClient: Scraper): Promise<Tweet
     const tweetsIds = twitterClient.searchTweets(`from:@${TWITTER_HANDLE}`, 50, SearchMode.Latest);
 
     for await(const tweet of tweetsIds) {
-        if (tweet) {
+        if (tweet && !isTweetCached(tweet, cache)) {
             const t: Tweet = {
                 ...tweet,
                 id: getTweetIdFromPermalink(tweet.id || ''),
@@ -52,7 +52,7 @@ export const tweetsGetterService = async (twitterClient: Scraper): Promise<Tweet
                 }
             }
 
-            const eligibleTweet = await getEligibleTweet(t, cache);
+            const eligibleTweet = await getEligibleTweet(t);
             if (eligibleTweet) {
                 tweets.unshift(eligibleTweet);
             }


### PR DESCRIPTION
When a tweet has already been synced, we can directly stop the data fetching for the current tweet and skip.