### PR TITLE
feat: add rate limit detection

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,3 +37,4 @@ export const DEBUG = (process.env.TOUITOMAMOUT_DEBUG || 'false') === 'true';
 export const DAEMON = (process.env.DAEMON || 'false') === 'true';
 export const DAEMON_PERIOD_MIN = parseInt(process.env.DAEMON_PERIOD_MIN ?? '7'); // Default 7 min
 export const VOID = '∅';
+export const API_RATE_LIMIT = parseInt(process.env.API_RATE_LIMIT ?? '60');


### PR DESCRIPTION
It's been a few weeks the sync can take a few **minutes** because of the twitter api rate limit.
Instead of making the sync lasts for a too long time, this MR implements rate limit detection.

A tweet has 60 seconds to get fetched. Timeout is reset at each new successful fetch. After a failure, the sync stops getting new tweets & continues to the next steps