### PR TITLE
feat: add image alt text

### DIFF
--- a/src/services/bluesky-sender.service.ts
+++ b/src/services/bluesky-sender.service.ts
@@ -21,7 +21,7 @@ export const blueskySenderService = async (client: BskyAgent | null, post: Blues
     }
 
     // Medias
-    const mediaAttachments: ComAtprotoRepoUploadBlob.Response[] = [];
+    const mediaAttachments: Array<ComAtprotoRepoUploadBlob.Response &{ alt_text: string | undefined}> = [];
     for (const media of medias) {
         if (!media.url) {
             continue;
@@ -44,8 +44,10 @@ export const blueskySenderService = async (client: BskyAgent | null, post: Blues
 
             await client.uploadBlob(blobData, { encoding: mimeType })
                 .then(async mediaSent => {
-                    mediaAttachments.push(mediaSent);
-
+                    mediaAttachments.push({
+                        ...mediaSent,
+                        ...{ alt_text: media.type === 'image' ? media.alt_text : '' }
+                    });
                 })
                 .catch(err => {
                     log.fail(err);
@@ -70,7 +72,7 @@ export const blueskySenderService = async (client: BskyAgent | null, post: Blues
                 $type: 'app.bsky.embed.recordWithMedia',
                 media: {
                     $type: 'app.bsky.embed.images',
-                    images: mediaAttachments.length ? mediaAttachments.map(i => ({ alt: '', image: i.data.blob.original })) : undefined
+                    images: mediaAttachments.length ? mediaAttachments.map(i => ({ alt: i.alt_text, image: i.data.blob.original })) : undefined
                 },
                 record: {
                     $type: 'app.bsky.embed.record',
@@ -105,7 +107,7 @@ export const blueskySenderService = async (client: BskyAgent | null, post: Blues
         if (mediaAttachments.length) {
             data.embed = {
                 $type: 'app.bsky.embed.images',
-                images: mediaAttachments.length ? mediaAttachments.map(i => ({ alt: '', image: i.data.blob.original })) : undefined
+                images: mediaAttachments.length ? mediaAttachments.map(i => ({ alt: i.alt_text, image: i.data.blob.original })) : undefined
             };
         }
     }

--- a/src/services/mastodon-sender.service.ts
+++ b/src/services/mastodon-sender.service.ts
@@ -29,7 +29,6 @@ export const mastodonSenderService = async (client: mastodon.rest.Client | null,
             (media.type === 'image' && mediaAttachments.length < BLUESKY_MEDIA_IMAGES_MAX_COUNT - 1) ||
             (media.type === 'video' && mediaAttachments.length === 0)
         ) {
-
             // Download
             log.text = `medias: ↓ (${mediaAttachments.length + 1}/${medias.length}) downloading`;
             const mediaBlob = await mediaDownloaderService(media.url);
@@ -37,7 +36,8 @@ export const mastodonSenderService = async (client: mastodon.rest.Client | null,
             // Upload
             log.text = `medias: ↑ (${mediaAttachments.length + 1}/${medias.length}) uploading`;
             await client.v2.media.create({
-                file: mediaBlob
+                file: mediaBlob,
+                description: media.type === 'image' && media.alt_text ? media.alt_text : null
             })
                 .then(async mediaSent => {
                     mediaAttachments.push(mediaSent);


### PR DESCRIPTION
This MR wires the twitter scrapper alternative text property to the corresponding ones on mastodon & bluesky.

Only **images** are supported.