### PR TITLE
fix(media): skip post sync without text nor media

### DIFF
--- a/src/services/bluesky-sender.service.ts
+++ b/src/services/bluesky-sender.service.ts
@@ -57,6 +57,12 @@ export const blueskySenderService = async (client: BskyAgent | null, post: Blues
         }
     }
 
+    // When no compatible media has been found and no text is present, skip the post
+    if(!mediaAttachments.length && !post.tweet.text) {
+        log.warn(`☁️ | post skipped: no compatible media nor text to post (tweet: ${post.tweet.id})`);
+        return;
+    }
+
     // Data creation
     const data: {
         [x: string]: unknown

--- a/src/services/mastodon-sender.service.ts
+++ b/src/services/mastodon-sender.service.ts
@@ -49,6 +49,12 @@ export const mastodonSenderService = async (client: mastodon.rest.Client | null,
         }
     }
 
+    // When no compatible media has been found and no text is present, skip the post
+    if(!mediaAttachments.length && !post.tweet.text) {
+        log.warn(`🦣️ | post skipped: no compatible media nor text to post (tweet: ${post.tweet.id})`);
+        return;
+    }
+
     log.text = `🦣 | toot sending: ${getPostExcerpt(post.tweet.text ?? VOID)}`;
 
     // Post


### PR DESCRIPTION
Fixes:
* skip post sync when no compatible-media nor text is available
* prevent logging to be blocked when the media is not compatible with bluesky

Closes #29 