### PR TITLE
ci: extract docs related jobs; make them run on docs path change only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,28 +6,6 @@ on:
   pull_request:
 
 jobs:
-  build-docs:
-    name: "Build documentation"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: docs
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v4
-
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.x'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build documentations
-        run: npm run build
-
   tests:
     name: "Tests Validation"
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: CI - Docs
+
+on:
+  pull_request:
+    paths:
+      - '/docs/**'
+
+jobs:
+  build-docs:
+    name: "Build documentation"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build documentations
+        run: npm run build


### PR DESCRIPTION
To make CI run a bit quicker, we'll now only run the documentation center jobs only when the `/docs` path has changes.

Since all the docusaurus project is contained inside its own folder, it should not be an issue when docs deps are changed.