### PR TITLE
feat: prevent unecessary sync

### DIFF
--- a/src/helpers/cache/migrations/helpers/prevent-migration-on-wrong-version.ts
+++ b/src/helpers/cache/migrations/helpers/prevent-migration-on-wrong-version.ts
@@ -1,0 +1,6 @@
+export const preventMigrationOnWrongVersion = (
+  outdatedCache: NonNullable<unknown>,
+  requiredVersion: string,
+) =>
+  (outdatedCache as NonNullable<unknown & { version: string }>).version !==
+  requiredVersion;

--- a/src/helpers/tweet/__tests__/tweet-formatter.spec.ts
+++ b/src/helpers/tweet/__tests__/tweet-formatter.spec.ts
@@ -1,0 +1,25 @@
+import { Tweet } from "@the-convocation/twitter-scraper";
+
+import { tweetFormatter } from "../tweet-formatter.js";
+
+jest.mock("../format-tweet-text.js", () => {
+  return {
+    formatTweetText: jest
+      .fn()
+      .mockImplementation((t: Tweet) => `formatted:${t.text}`),
+  };
+});
+
+describe("tweetFormatter", () => {
+  it("should properly format the give tweet", () => {
+    const result = tweetFormatter({
+      text: "text",
+      timestamp: 966236400,
+    } as Tweet);
+
+    expect(result).toStrictEqual({
+      text: "formatted:text",
+      timestamp: 966236400000,
+    });
+  });
+});

--- a/src/helpers/tweet/index.ts
+++ b/src/helpers/tweet/index.ts
@@ -3,3 +3,4 @@ export * from "./is-tweet-cached.js";
 export * from "./keep-recent-tweets.js";
 export * from "./keep-self-quotes.js";
 export * from "./keep-self-replies.js";
+export * from "./tweet-formatter.js";

--- a/src/helpers/tweet/tweet-formatter.ts
+++ b/src/helpers/tweet/tweet-formatter.ts
@@ -1,0 +1,11 @@
+import { Tweet } from "@the-convocation/twitter-scraper";
+
+import { formatTweetText } from "./format-tweet-text.js";
+
+export const tweetFormatter = (tweet: Tweet): Tweet => {
+  return {
+    ...tweet,
+    timestamp: (tweet.timestamp ?? 0) * 1000,
+    text: formatTweetText(tweet),
+  };
+};


### PR DESCRIPTION
This PR adds a checks on the 5 most recent tweets.
The posts sync will be skipped if the first eligible tweet (in these 5 most recent one) is already cached. (If not, the sync is done).