### PR TITLE
fix(bluesky): properly catch unsupported media error

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -14,6 +14,7 @@ import {
   MASTODON_ACCESS_TOKEN,
   MASTODON_INSTANCE,
   SYNC_BLUESKY,
+  SYNC_DRY_RUN,
   SYNC_MASTODON,
   TOUITOMAMOUT_VERSION,
   TWITTER_HANDLE,
@@ -48,6 +49,14 @@ export const configuration = async (): Promise<{
   });
 
   console.log(`Touitomamout@v${TOUITOMAMOUT_VERSION}`);
+
+  if (SYNC_DRY_RUN) {
+    ora({
+      color: "gray",
+      prefixText: oraPrefixer("✌️ dry run"),
+    }).info("mode enabled (no post will be posted)");
+  }
+
   // Init configuration
   await createCacheFile();
   await runMigrations();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -58,8 +58,9 @@ export const SYNC_PROFILE_NAME =
   (process.env.SYNC_PROFILE_NAME || "false") === "true";
 export const SYNC_PROFILE_HEADER =
   (process.env.SYNC_PROFILE_HEADER || "false") === "true";
+export const SYNC_DRY_RUN = (process.env.SYNC_DRY_RUN || "false") === "true";
 export const DEBUG = (process.env.TOUITOMAMOUT_DEBUG || "false") === "true";
 export const DAEMON = (process.env.DAEMON || "false") === "true";
 export const VOID = "∅";
-export const API_RATE_LIMIT = parseInt(process.env.API_RATE_LIMIT ?? "10");
+export const API_RATE_LIMIT = parseInt(process.env.API_RATE_LIMIT ?? "30");
 export const TOUITOMAMOUT_VERSION = buildInfo.version || "0.0.0";

--- a/src/helpers/medias/upload-bluesky-media.ts
+++ b/src/helpers/medias/upload-bluesky-media.ts
@@ -1,5 +1,6 @@
 import { BskyAgent } from "@atproto/api";
 
+import { DEBUG } from "../../constants.js";
 import { parseBlobForBluesky } from "./parse-blob-for-bluesky.js";
 
 /**
@@ -13,6 +14,17 @@ export const uploadBlueskyMedia = async (
   if (!blueskyClient) {
     return null;
   }
-  const { mimeType, blobData } = await parseBlobForBluesky(mediaBlob);
-  return await blueskyClient?.uploadBlob(blobData, { encoding: mimeType });
+  return await parseBlobForBluesky(mediaBlob)
+    .then(
+      ({ blobData, mimeType }) =>
+        blueskyClient?.uploadBlob(blobData, {
+          encoding: mimeType,
+        }),
+    )
+    .catch((err) => {
+      if (DEBUG) {
+        console.log(err);
+      }
+      return null;
+    });
 };

--- a/src/services/posts-synchronizer.service.ts
+++ b/src/services/posts-synchronizer.service.ts
@@ -4,6 +4,7 @@ import { Scraper } from "@the-convocation/twitter-scraper";
 import { mastodon } from "masto";
 import ora from "ora";
 
+import { SYNC_DRY_RUN } from "../constants.js";
 import { getCache } from "../helpers/cache/index.js";
 import { oraPrefixer } from "../helpers/logs/ora-prefixer.js";
 import { makePost } from "../helpers/post/make-post.js";
@@ -42,9 +43,10 @@ export const postsSynchronizerService = async (
         log,
       );
 
-      await mastodonSenderService(mastodonClient, mastodonPost, medias, log);
-      await blueskySenderService(blueskyClient, blueskyPost, medias, log);
-
+      if (!SYNC_DRY_RUN) {
+        await mastodonSenderService(mastodonClient, mastodonPost, medias, log);
+        await blueskySenderService(blueskyClient, blueskyPost, medias, log);
+      }
       if (mastodonClient || blueskyPost) {
         synchronizedPostsCountThisRun.inc();
       }


### PR DESCRIPTION
### Unsupported media error for bluesky

```bash
content-sync    ⚠ medias: ↯ (1/1) skipped for ☁️ bluesky : Media type not supported (video/mp4)
```

### Dry run mode
Useful to test the sync process without posting.

```bash
✌️ dry run      ℹ mode enabled (no post will be posted)
```