### PR TITLE
fix(cache): prevent cache creation to break old data

### DIFF
--- a/src/helpers/cache/__tests__/create-cache.spec.ts
+++ b/src/helpers/cache/__tests__/create-cache.spec.ts
@@ -2,7 +2,6 @@ import { access } from "fs/promises";
 
 import { INSTANCE_ID } from "../../../constants.js";
 import { createCacheFile } from "../create-cache.js";
-import { getCache } from "../get-cache.js";
 import { writeToCacheFile } from "../write-to-cache-file.js";
 
 jest.mock("fs/promises", () => ({
@@ -18,14 +17,6 @@ jest.mock("../../../constants.js", () => {
     CACHE_PATH: "./cache.json",
   };
 });
-
-jest.mock("../get-cache.js", () => ({
-  getCache: jest.fn().mockResolvedValue({
-    instance: {
-      id: INSTANCE_ID,
-    },
-  }),
-}));
 
 jest.mock("../write-to-cache-file.js", () => ({
   writeToCacheFile: jest.fn(),
@@ -46,7 +37,6 @@ describe("createCache", () => {
       await createCacheFile();
 
       expect(promiseAccessMock).toHaveBeenCalledTimes(1);
-      expect(getCache).toHaveBeenCalledTimes(1);
       expect(writeToCacheFile).not.toHaveBeenCalled();
     });
   });
@@ -60,7 +50,6 @@ describe("createCache", () => {
       await createCacheFile();
 
       expect(promiseAccessMock).toHaveBeenCalledTimes(1);
-      expect(getCache).not.toHaveBeenCalled();
       expect(writeToCacheFile).toHaveBeenCalledWith({
         version: "0.2",
         instance: { id: INSTANCE_ID },

--- a/src/helpers/cache/create-cache.ts
+++ b/src/helpers/cache/create-cache.ts
@@ -1,17 +1,12 @@
 import { access, constants } from "fs/promises";
 
 import { CACHE_PATH, INSTANCE_ID } from "../../constants.js";
-import { getCache } from "./get-cache.js";
 import { writeToCacheFile } from "./write-to-cache-file.js";
 
 export const createCacheFile = async () => {
   try {
     // Check if the file exists
     await access(CACHE_PATH, constants.F_OK);
-    const cache = await getCache();
-    if (cache.instance.id !== INSTANCE_ID) {
-      throw new Error(`Cache for instance ${INSTANCE_ID} not found`);
-    }
   } catch {
     writeToCacheFile({
       version: "0.2",


### PR DESCRIPTION
This PR fixes the cache creation method.

Previously, Touitomamout was checking for the instance id. Since a recent migration, the instance id was not saved in the same location, so I updated that check, but this is preventing old caches to be compatible with Touitomamout.

This is now fixed.

Thanks to @kai17 for reporting this issue ( #115 ) 🤝 . 
