### PR TITLE
fix(formatter): decode tweet text HTML entities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^20.9.0",
         "cli-spinners": "^2.9.1",
         "dotenv": "^16.3.1",
+        "html-entities": "^2.4.0",
         "html-escaper": "^3.0.3",
         "masto": "^6.4.2",
         "mime": "^3.0.0",
@@ -4719,6 +4720,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/html-entities": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.4.0.tgz",
+      "integrity": "sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ]
     },
     "node_modules/html-escaper": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/node": "^20.9.0",
     "cli-spinners": "^2.9.1",
     "dotenv": "^16.3.1",
+    "html-entities": "^2.4.0",
     "html-escaper": "^3.0.3",
     "masto": "^6.4.2",
     "mime": "^3.0.0",

--- a/src/helpers/tweet/__tests__/format-tweet-text.spec.ts
+++ b/src/helpers/tweet/__tests__/format-tweet-text.spec.ts
@@ -3,6 +3,17 @@ import { Tweet } from "@the-convocation/twitter-scraper";
 import { formatTweetText } from "../format-tweet-text.js";
 
 describe("formatTweetText", () => {
+  it("should decode html entities from the text", () => {
+    const tweet: Tweet = {
+      text: "one elephant &amp; one mammoth make two animals, right?&lt; &gt; &amp; &quot; &apos; &copy; &reg; &trade; &cent; &pound; &euro; &yen; &sect; &deg; &plusmn; &times; &divide;",
+      urls: [],
+    } as unknown as Tweet;
+    const result = formatTweetText(tweet);
+    expect(result).toStrictEqual(
+      "one elephant & one mammoth make two animals, right?< > & \" ' © ® ™ ¢ £ € ¥ § ° ± × ÷",
+    );
+  });
+
   describe("when the tweet has links", () => {
     it("should remove the t.co links from the text", () => {
       const tweet: Tweet = {

--- a/src/helpers/tweet/format-tweet-text.ts
+++ b/src/helpers/tweet/format-tweet-text.ts
@@ -1,4 +1,5 @@
 import { Tweet } from "@the-convocation/twitter-scraper";
+import { decode } from "html-entities";
 
 export const formatTweetText = (tweet: Tweet): string => {
   let text = tweet.text ?? "";
@@ -10,6 +11,9 @@ export const formatTweetText = (tweet: Tweet): string => {
 
   // Remove medias t.co links
   text = text.replaceAll(/https:\/\/t\.co\/\w+/g, "");
+
+  // Replace HTML entities with their unicode equivalent
+  text = decode(text);
 
   // Return formatted
   return text.trim();


### PR DESCRIPTION
This PR makes the tweet formater to decode the HTML entities so they are properly rendered when the post is sent.

Closes #124 .