### PR TITLE
fix(bluesky): make card image optional

### DIFF
--- a/src/helpers/bluesky/__tests__/get-bluesky-link-metadata.spec.ts
+++ b/src/helpers/bluesky/__tests__/get-bluesky-link-metadata.spec.ts
@@ -53,7 +53,24 @@ describe("getBlueskyLinkMetadata", () => {
     });
   });
 
-  it("should return the metadata if data is found", async () => {
+  describe("when no image if found", () => {
+    it("should return the metadata without image property", async () => {
+      const result = await getBlueskyLinkMetadata("https://google.com", {
+        uploadBlob: uploadBlobMock,
+      } as unknown as BskyAgent);
+
+      expect(result).toStrictEqual({
+        ...METADATA_MOCK,
+        image: undefined,
+        title: "Google",
+        url: "https://google.com",
+        description:
+          "Search the world's information, including webpages, images, videos and more. Google has many special features to help you find exactly what you're looking for.",
+      });
+    });
+  });
+
+  it("should return null if not data is found", async () => {
     const result = await getBlueskyLinkMetadata(
       "https://thisturldoesnotexist.example.com",
       {

--- a/src/helpers/bluesky/get-bluesky-link-metadata.ts
+++ b/src/helpers/bluesky/get-bluesky-link-metadata.ts
@@ -17,8 +17,18 @@ export const getBlueskyLinkMetadata = async (
   client: bsky.BskyAgent,
 ): Promise<BlueskyLinkMetadata | null> => {
   const data = await fetchLinkMetadata(url);
+
+  // Without metadata, stop
   if (!data) {
     return null;
+  }
+
+  // Metadata without image
+  if (!data.image) {
+    return {
+      ...data,
+      image: undefined,
+    };
   }
 
   const mediaBlob = await mediaDownloaderService(data.image);
@@ -29,11 +39,8 @@ export const getBlueskyLinkMetadata = async (
     encoding: blueskyBlob.mimeType,
   });
 
-  if (blueskyBlob) {
-    return {
-      ...data,
-      image: media,
-    };
-  }
-  return null;
+  return {
+    ...data,
+    image: blueskyBlob ? media : undefined,
+  };
 };

--- a/src/services/bluesky-sender.service.ts
+++ b/src/services/bluesky-sender.service.ts
@@ -155,7 +155,7 @@ export const blueskySenderService = async (
             uri: card.url,
             title: card.title,
             description: card.description,
-            thumb: card.image.data.blob.original,
+            thumb: card.image?.data.blob.original,
             $type: "app.bsky.embed.external",
           },
         }

--- a/src/types/link-metadata.ts
+++ b/src/types/link-metadata.ts
@@ -10,5 +10,5 @@ export type LinkMetadata = {
 };
 
 export type BlueskyLinkMetadata = Omit<LinkMetadata, "image"> & {
-  image: bsky.ComAtprotoRepoUploadBlob.Response;
+  image: bsky.ComAtprotoRepoUploadBlob.Response | undefined;
 };


### PR DESCRIPTION
This MR allows Touitomamout not failing while trying to pull the image supposed to be used for the Bluesky card when the image is not referenced.

Closes #156.