### PR TITLE
Add webp support

### DIFF
--- a/src/helpers/medias/parse-blob-for-bluesky.ts
+++ b/src/helpers/medias/parse-blob-for-bluesky.ts
@@ -19,7 +19,7 @@ export const parseBlobForBluesky = async (
   ).catch(() => inputBlob);
 
   return new Promise<BlueskyBlob>((resolve, reject) => {
-    const allowedMimeTypes = ["image/jpeg", "image/jpg", "image/png"];
+    const allowedMimeTypes = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
     const mimeType = blob.type;
 
     blob.arrayBuffer().then((ab) => {


### PR DESCRIPTION
There was an account that wouldn't sync because it would get hung up on "unsupported file" of image/webp. I looked into it and Bluesky does accept webp images. I added it to the array and tried to sync that account and it worked.