### PR TITLE
chore: migrate from bskyagent to atpagent

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -1,4 +1,4 @@
-import { BskyAgent } from "@atproto/api";
+import { AtpAgent } from "@atproto/api";
 import { ResponseType, ResponseTypeNames } from "@atproto/xrpc";
 import pm2 from "@pm2/io";
 import type Counter from "@pm2/io/build/main/utils/metrics/counter";
@@ -32,7 +32,7 @@ export const configuration = async (): Promise<{
   synchronizedPostsCountThisRun: Counter;
   twitterClient: Scraper;
   mastodonClient: null | mastodon.rest.Client;
-  blueskyClient: null | BskyAgent;
+  blueskyClient: null | AtpAgent;
 }> => {
   // Error handling
   const rules = buildConfigurationRules();
@@ -116,7 +116,7 @@ export const configuration = async (): Promise<{
       prefixText: oraPrefixer("☁️ client"),
     }).start("connecting to bluesky...");
 
-    blueskyClient = new BskyAgent({
+    blueskyClient = new AtpAgent({
       service: `https://${BLUESKY_INSTANCE}`,
     });
     await blueskyClient

--- a/src/helpers/bluesky/__tests__/get-bluesky-chunk-link-metadata.spec.ts
+++ b/src/helpers/bluesky/__tests__/get-bluesky-chunk-link-metadata.spec.ts
@@ -1,4 +1,4 @@
-import { BskyAgent, RichText } from "@atproto/api";
+import { AtpAgent, RichText } from "@atproto/api";
 
 import { getBlueskyChunkLinkMetadata } from "../get-bluesky-chunk-link-metadata";
 import { getBlueskyLinkMetadata } from "../get-bluesky-link-metadata";
@@ -28,7 +28,7 @@ describe("getBlueskyChunkLinkMetadata", () => {
       const richText = new RichText({
         text: "The potato is king. Learn more here: https://example.com/potato",
       });
-      const client = new BskyAgent({
+      const client = new AtpAgent({
         service: `https://bsky.social`,
       });
       await richText.detectFacets(client);
@@ -47,7 +47,7 @@ describe("getBlueskyChunkLinkMetadata", () => {
       const richText = new RichText({
         text: "The potato is king. Learn more here.",
       });
-      const client = new BskyAgent({
+      const client = new AtpAgent({
         service: `https://bsky.social`,
       });
       await richText.detectFacets(client);

--- a/src/helpers/bluesky/__tests__/get-bluesky-link-metadata.spec.ts
+++ b/src/helpers/bluesky/__tests__/get-bluesky-link-metadata.spec.ts
@@ -1,4 +1,4 @@
-import { BskyAgent } from "@atproto/api";
+import { AtpAgent } from "@atproto/api";
 
 import { getBlueskyLinkMetadata } from "../get-bluesky-link-metadata";
 import { METADATA_MOCK } from "./mocks/metadata";
@@ -39,7 +39,7 @@ describe("getBlueskyLinkMetadata", () => {
   it("should return the metadata if data is found", async () => {
     const result = await getBlueskyLinkMetadata("https://bsky.app", {
       uploadBlob: uploadBlobMock,
-    } as unknown as BskyAgent);
+    } as unknown as AtpAgent);
     expect(result).toStrictEqual({
       ...METADATA_MOCK,
       image: {
@@ -57,7 +57,7 @@ describe("getBlueskyLinkMetadata", () => {
     it("should return the metadata without image property", async () => {
       const result = await getBlueskyLinkMetadata("https://github.com", {
         uploadBlob: uploadBlobMock,
-      } as unknown as BskyAgent);
+      } as unknown as AtpAgent);
 
       expect(result).toStrictEqual({
         ...METADATA_MOCK,
@@ -82,7 +82,7 @@ describe("getBlueskyLinkMetadata", () => {
       "https://thisturldoesnotexist.example.com",
       {
         uploadBlob: uploadBlobMock,
-      } as unknown as BskyAgent,
+      } as unknown as AtpAgent,
     );
     expect(result).toBeNull();
   });

--- a/src/helpers/bluesky/get-bluesky-chunk-link-metadata.ts
+++ b/src/helpers/bluesky/get-bluesky-chunk-link-metadata.ts
@@ -1,4 +1,4 @@
-import { BskyAgent, RichText } from "@atproto/api";
+import { AtpAgent, RichText } from "@atproto/api";
 
 import { BlueskyLinkMetadata } from "../../types/link-metadata";
 import { getBlueskyLinkMetadata } from "./get-bluesky-link-metadata";
@@ -7,12 +7,12 @@ import { getBlueskyLinkMetadata } from "./get-bluesky-link-metadata";
  * Retrieves the metadata of the first link found in the given richtext.
  *
  * @param {RichText} richText - The richtext to search for links.
- * @param {BskyAgent} client - The BskyAgent client for making API calls.
+ * @param {AtpAgent} client - The AtpAgent client for making API calls.
  * @returns {Promise<BlueskyLinkMetadata | null>} A promise that resolves to the metadata of the first link found, or null if no link is found.
  */
 export const getBlueskyChunkLinkMetadata = async (
   richText: RichText,
-  client: BskyAgent,
+  client: AtpAgent,
 ): Promise<BlueskyLinkMetadata | null> => {
   let card = null;
   for (const seg of richText.segments()) {

--- a/src/helpers/bluesky/get-bluesky-link-metadata.ts
+++ b/src/helpers/bluesky/get-bluesky-link-metadata.ts
@@ -1,4 +1,4 @@
-import { BskyAgent } from "@atproto/api";
+import { AtpAgent } from "@atproto/api";
 
 import { mediaDownloaderService } from "../../services";
 import { BlueskyLinkMetadata } from "../../types/link-metadata";
@@ -9,12 +9,12 @@ import { fetchLinkMetadata } from "./fetch-link-metadata";
  * Retrieves Bluesky Link metadata asynchronously.
  *
  * @param {string} url - The URL of the link for which metadata is to be retrieved.
- * @param {BskyAgent} client - The BskyAgent client used for uploading the media.
+ * @param {AtpAgent} client - The AtpAgent client used for uploading the media.
  * @returns {Promise<BlueskyLinkMetadata | null>} - A promise that resolves to the Bluesky Link metadata or null if not found.
  */
 export const getBlueskyLinkMetadata = async (
   url: string,
-  client: BskyAgent,
+  client: AtpAgent,
 ): Promise<BlueskyLinkMetadata | null> => {
   const data = await fetchLinkMetadata(url);
 

--- a/src/helpers/medias/__tests__/upload-bluesky-media.spec.ts
+++ b/src/helpers/medias/__tests__/upload-bluesky-media.spec.ts
@@ -1,4 +1,4 @@
-import { BskyAgent } from "@atproto/api";
+import { AtpAgent } from "@atproto/api";
 
 import { uploadBlueskyMedia } from "../upload-bluesky-media";
 import { makeBlobFromFile } from "./helpers/make-blob-from-file";
@@ -18,7 +18,7 @@ describe("uploadBlueskyMedia", () => {
     const mediaBlob = await makeBlobFromFile("image-png.png", "image/png");
     const blueskyClient = {
       uploadBlob: uploadBlobMock,
-    } as unknown as BskyAgent;
+    } as unknown as AtpAgent;
 
     const result = await uploadBlueskyMedia(mediaBlob, blueskyClient);
 
@@ -41,7 +41,7 @@ describe("uploadBlueskyMedia", () => {
       const mediaBlob = new Blob();
       const blueskyClient = {
         uploadBlob: uploadBlobMock,
-      } as unknown as BskyAgent;
+      } as unknown as AtpAgent;
 
       const result = await uploadBlueskyMedia(mediaBlob, blueskyClient);
 

--- a/src/helpers/medias/upload-bluesky-media.ts
+++ b/src/helpers/medias/upload-bluesky-media.ts
@@ -1,4 +1,4 @@
-import { BskyAgent, ComAtprotoRepoUploadBlob } from "@atproto/api";
+import { AtpAgent, ComAtprotoRepoUploadBlob } from "@atproto/api";
 
 import { DEBUG } from "../../constants";
 import { parseBlobForBluesky } from "./parse-blob-for-bluesky";
@@ -9,7 +9,7 @@ import { parseBlobForBluesky } from "./parse-blob-for-bluesky";
  */
 export const uploadBlueskyMedia = async (
   mediaBlob: Blob,
-  blueskyClient: BskyAgent | null,
+  blueskyClient: AtpAgent | null,
 ): Promise<ComAtprotoRepoUploadBlob.Response | null> => {
   if (!blueskyClient) {
     return null;

--- a/src/helpers/post/__tests__/make-bluesky-post.spec.ts
+++ b/src/helpers/post/__tests__/make-bluesky-post.spec.ts
@@ -1,4 +1,4 @@
-import { AppBskyFeedPost, BskyAgent } from "@atproto/api";
+import { AppBskyFeedPost, AtpAgent } from "@atproto/api";
 
 import { makeTweetMock } from "../../../services/__tests__/helpers/make-tweet-mock";
 import { makeBlueskyPost } from "../make-bluesky-post";
@@ -17,7 +17,7 @@ describe("makeBlueskyPost", () => {
   it("should build a post", async () => {
     const client = {
       getProfile: async () => ({ data: { handle: "username" } }),
-    } as unknown as BskyAgent;
+    } as unknown as AtpAgent;
     const tweet = makeTweetMock({ id: "tweetId" });
     const result = await makeBlueskyPost(client, tweet);
 
@@ -46,7 +46,7 @@ describe("makeBlueskyPost", () => {
             cid: "cid",
             value: {} as AppBskyFeedPost.Record,
           }),
-        } as unknown as BskyAgent;
+        } as unknown as AtpAgent;
 
         const tweet = makeTweetMock({
           [tweetProperty + "Id"]: "quotedId",

--- a/src/helpers/post/__tests__/make-post.spec.ts
+++ b/src/helpers/post/__tests__/make-post.spec.ts
@@ -1,4 +1,4 @@
-import { BskyAgent } from "@atproto/api";
+import { AtpAgent } from "@atproto/api";
 import { mastodon } from "masto";
 import ora from "ora";
 
@@ -16,7 +16,7 @@ vi.mock("../make-bluesky-post", () => ({
 }));
 
 const mastodonClient = {} as unknown as mastodon.rest.Client;
-const blueskyClient = {} as unknown as BskyAgent;
+const blueskyClient = {} as unknown as AtpAgent;
 
 const tweet = makeTweetMock();
 const madePostMock = {

--- a/src/helpers/post/make-bluesky-post.ts
+++ b/src/helpers/post/make-bluesky-post.ts
@@ -1,4 +1,4 @@
-import { BskyAgent, RichText } from "@atproto/api";
+import { AtpAgent, RichText } from "@atproto/api";
 import { Tweet } from "@the-convocation/twitter-scraper";
 
 import { BLUESKY_IDENTIFIER } from "../../constants";
@@ -8,7 +8,7 @@ import { getCachedPostChunk } from "../cache/get-cached-post-chunk";
 import { splitTextForBluesky } from "../tweet/split-tweet-text";
 
 export const makeBlueskyPost = async (
-  client: BskyAgent,
+  client: AtpAgent,
   tweet: Tweet,
 ): Promise<BlueskyPost> => {
   const username = await client

--- a/src/helpers/post/make-post.ts
+++ b/src/helpers/post/make-post.ts
@@ -1,4 +1,4 @@
-import { BskyAgent } from "@atproto/api";
+import { AtpAgent } from "@atproto/api";
 import { Tweet } from "@the-convocation/twitter-scraper";
 import { mastodon } from "masto";
 import { Ora } from "ora";
@@ -36,7 +36,7 @@ const chunkLogger = (
 export const makePost = async (
   tweet: Tweet,
   mastodonClient: mastodon.rest.Client | null,
-  blueskyClient: BskyAgent | null,
+  blueskyClient: AtpAgent | null,
   log: Ora,
   counters: { current: number; total: number },
 ): Promise<Post> => {

--- a/src/services/__tests__/bluesky-sender.service.spec.ts
+++ b/src/services/__tests__/bluesky-sender.service.spec.ts
@@ -1,4 +1,4 @@
-import { BskyAgent } from "@atproto/api";
+import { AtpAgent } from "@atproto/api";
 import ora from "ora";
 
 import { makeBlobFromFile } from "../../helpers/medias/__tests__/helpers/make-blob-from-file";
@@ -22,7 +22,7 @@ vi.mock("../media-downloader.service", () => ({
   mediaDownloaderService: vi.fn(),
 }));
 const mediaDownloaderServiceMock = mediaDownloaderService as vi.Mock;
-const client = new BskyAgent({
+const client = new AtpAgent({
   service: `https://bsky.social`,
 });
 

--- a/src/services/__tests__/posts-synchronizer-service.spec.ts
+++ b/src/services/__tests__/posts-synchronizer-service.spec.ts
@@ -1,4 +1,4 @@
-import { BskyAgent } from "@atproto/api";
+import { AtpAgent } from "@atproto/api";
 import * as Counter from "@pm2/io/build/main/utils/metrics/counter";
 import { Scraper } from "@the-convocation/twitter-scraper";
 import { mastodon } from "masto";
@@ -58,7 +58,7 @@ describe("postsSynchronizerService", () => {
   it("should return a response with the expected shape", async () => {
     const twitterClient = new MockTwitterClient(3) as unknown as Scraper;
     const mastodonClient = {} as mastodon.rest.Client;
-    const blueskyClient = {} as BskyAgent;
+    const blueskyClient = {} as AtpAgent;
     const synchronizedPostsCountThisRun = {
       inc: vi.fn(),
     } as unknown as Counter.default;

--- a/src/services/__tests__/profile-synchronizer.service.spec.ts
+++ b/src/services/__tests__/profile-synchronizer.service.spec.ts
@@ -1,4 +1,4 @@
-import { BskyAgent } from "@atproto/api";
+import { AtpAgent } from "@atproto/api";
 import { Profile, Scraper } from "@the-convocation/twitter-scraper";
 import { mastodon } from "masto";
 import { vi } from "vitest";
@@ -82,7 +82,7 @@ describe("profileSynchronizerService", () => {
   const updateBlueskyProfileSpy = vi.fn();
   const blueskyClient = {
     upsertProfile: updateBlueskyProfileSpy,
-  } as unknown as BskyAgent;
+  } as unknown as AtpAgent;
 
   // Actual tests
   describe.each`

--- a/src/services/bluesky-sender.service.ts
+++ b/src/services/bluesky-sender.service.ts
@@ -1,4 +1,4 @@
-import { BskyAgent, RichText } from "@atproto/api";
+import { AtpAgent, RichText } from "@atproto/api";
 import { Ora } from "ora";
 
 import { BACKDATE_BLUESKY_POSTS, DEBUG, VOID } from "../constants";
@@ -25,7 +25,7 @@ const BLUESKY_MEDIA_IMAGES_MAX_COUNT = 4;
  * An async method in charge of handling Bluesky posts computation & uploading.
  */
 export const blueskySenderService = async (
-  client: BskyAgent | null,
+  client: AtpAgent | null,
   post: BlueskyPost | null,
   medias: Media[],
   log: Ora,

--- a/src/services/posts-synchronizer.service.ts
+++ b/src/services/posts-synchronizer.service.ts
@@ -1,4 +1,4 @@
-import { BskyAgent } from "@atproto/api";
+import { AtpAgent } from "@atproto/api";
 import * as Counter from "@pm2/io/build/main/utils/metrics/counter";
 import { Scraper } from "@the-convocation/twitter-scraper";
 import { mastodon } from "masto";
@@ -19,7 +19,7 @@ import { tweetsGetterService } from "./tweets-getter.service";
 export const postsSynchronizerService = async (
   twitterClient: Scraper,
   mastodonClient: mastodon.rest.Client | null,
-  blueskyClient: BskyAgent | null,
+  blueskyClient: AtpAgent | null,
   synchronizedPostsCountThisRun: Counter.default,
 ): Promise<SynchronizerResponse & { metrics: Metrics }> => {
   const tweets = await tweetsGetterService(twitterClient);

--- a/src/services/profile-synchronizer.service.ts
+++ b/src/services/profile-synchronizer.service.ts
@@ -1,4 +1,4 @@
-import { BskyAgent } from "@atproto/api";
+import { AtpAgent } from "@atproto/api";
 import { Scraper } from "@the-convocation/twitter-scraper";
 import { mastodon } from "masto";
 import ora from "ora";
@@ -24,7 +24,7 @@ import { mediaDownloaderService } from "./media-downloader.service";
 export const profileSynchronizerService = async (
   twitterClient: Scraper,
   mastodonClient: mastodon.rest.Client | null,
-  blueskyClient: BskyAgent | null,
+  blueskyClient: AtpAgent | null,
 ): Promise<SynchronizerResponse> => {
   const log = ora({
     color: "cyan",

--- a/src/services/profile-synchronizer.service.ts
+++ b/src/services/profile-synchronizer.service.ts
@@ -160,15 +160,12 @@ export const profileSynchronizerService = async (
   // Update profile images hash
   await updateCacheEntry(
     "profile",
-    Object.entries(profileUpdate).reduce(
-      (updated, [type, { hash, ..._rest }]) => {
-        return {
-          ...updated,
-          [type]: hash,
-        };
-      },
-      {} as ProfileCache,
-    ),
+    Object.entries(profileUpdate).reduce((updated, [type, { hash }]) => {
+      return {
+        ...updated,
+        [type]: hash,
+      };
+    }, {} as ProfileCache),
   );
 
   log.succeed("task finished");

--- a/src/types/synchronizer-response.ts
+++ b/src/types/synchronizer-response.ts
@@ -1,9 +1,9 @@
-import { BskyAgent } from "@atproto/api";
+import { AtpAgent } from "@atproto/api";
 import { Scraper } from "@the-convocation/twitter-scraper";
 import { mastodon } from "masto";
 
 export type SynchronizerResponse = {
   twitterClient: Scraper;
   mastodonClient: null | mastodon.rest.Client;
-  blueskyClient: null | BskyAgent;
+  blueskyClient: null | AtpAgent;
 };


### PR DESCRIPTION
This MR removes the usage of BskyAgent, now deprecated, in favor of the new symbol: AtpAgent.