### PR TITLE
fix(bluesky): properly set root post on replies

### DIFF
--- a/src/services/bluesky-sender.service.ts
+++ b/src/services/bluesky-sender.service.ts
@@ -219,7 +219,14 @@ export const blueskySenderService = async (
 
     if (chunkIndex === 0) {
       if (post.replyPost) {
-        data.reply = buildReplyEntry(post.replyPost);
+        if (post.replyPost.value.reply) {
+          data.reply = buildReplyEntry(
+            post.replyPost.value.reply.root,
+            post.replyPost,
+          );
+        } else {
+          data.reply = buildReplyEntry(post.replyPost);
+        }
       }
     } else {
       data.reply = buildReplyEntry(


### PR DESCRIPTION
# Summary

Chained replies (threads) keep track of the root post to properly display the thread. When adding a new reply to a post, it's therefore necessary to check first if that post was itself a reply: if it is, we simply copy its root post reference